### PR TITLE
Manual MarkDown backup of the original HTML 4.01 documentation

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -1,0 +1,117 @@
+# Examples
+
+Common GNU tools (`wget`, `grep`, ...) are assumed.
+
+## XML
+
+### Use the Slashdot backend.
+
+    % wget -q -O - http://slashdot.org/slashdot.xml | xml2
+    
+    /backslash/@xmlns:backslash=http://slashdot.org/backslash.dtd
+    /backslash/story/title=More on Athlon Overclocking
+    /backslash/story/url=http://slashdot.org/articles/00/03/04/1441248.shtml
+    /backslash/story/time=2000-03-05 03:40:47
+    /backslash/story/author=Hemos
+    /backslash/story/department=better-faster-strong
+    /backslash/story/topic=amd
+    /backslash/story/comments=56
+    /backslash/story/section=articles
+    /backslash/story/image=topicamd.gif
+    /backslash/story
+    /backslash/story/title=New Atari Jaguar Game Running $1,225 on eBay
+    /backslash/story/url=http://slashdot.org/articles/00/03/02/1430232.shtml
+    ...
+
+### Now, just the headlines.
+
+    % wget -q -O - http://slashdot.org/slashdot.xml | xml2 | grep story/title= | cut -d= -f 2-
+    
+    More on Athlon Overclocking
+    New Atari Jaguar Game Running $1,225 on eBay
+    AT&T;'s Korn Shell Source Code Released
+    TheBench.org: Community Cartooning
+    OpenGL for Palm OS Environment
+    Banner Ads on Your Cell Phone
+    Burning Money on Open Source
+    Embedded OpenBSD Running the Stallion ePipe
+    Bezos Responds to Tim O'Reilly's Open Letter
+    Update on 'Blame Canada' and the Oscars
+
+### How big is the Red Hat 6.1 libxml RPM?
+
+For variety, we use awk rather than grep and cut:
+
+    % wget -q -O - http://rpmfind.net/linux/RDF/redhat/6.1/i386/libxml-1.4.0-1.i386.rdf | xml2 | awk -F= '/RPM:Size/ {print $2}'
+    
+    704399
+
+### What is the melting point of silicon?
+
+<sup>More awkitude. Don't let your CPU get hotter than this!</sup>
+
+    % wget -q -O - http://metalab.unc.edu/xml/examples/periodic_table/allelements.xml |  xml2 | awk '/ATOM\/NAME=Silicon/,!/ATOM\//' |  awk -F\= '/MELTING_POINT/ {print $2}'
+    
+    Kelvin
+    1683
+
+<sup>(1683ºK is 2570ºF, by the way.)</sup>
+
+
+## HTML
+
+
+### Fetch the Slashdot news page.
+
+You'll probably see some warnings. (Slashdot has some of the worst HTML I've ever seen...)
+
+    % wget -q -O - http://slashdot.org/ | html2
+    
+    /html/head/title=Slashdot:News for Nerds. Stuff that Matters.
+    /html/head=
+    /html=
+    /html/body/@bgcolor=#000000
+    /html/body/@text=#000000
+    /html/body/@link=#006666
+    /html/body/@vlink=#000000
+    /html/body=
+    /html/body/center/a/@href=http://209.207.224.220/redir.pl?1789
+    /html/body/center/a/@target=_top
+    ...
+
+### Find all the links.
+
+If you find the warnings distracting, redirect the standard error of `html2` to `/dev/null`.
+
+    % wget -q -O - http://slashdot.org/ | html2 | grep 'a/@href' | cut -d\= -f 2- | sort | uniq
+    
+    /about.shtml
+    /advertising.shtml
+    /article.pl?sid=99/03/31/0137221
+    /article.pl?sid=99/04/25/1438249
+    /article.pl?sid=99/04/27/0310247
+    /article.pl?sid=99/04/29/0124247
+    /article.pl?sid=99/08/24/1327256&mode;=thread
+    /awards.shtml
+    /cheesyportal.shtml
+    /code.shtml
+    ...
+
+### Change some colors.
+
+This pipeline uses both `html2` and `2html` to effect a round-trip. In the middle, `sed` applies a transformation, turning the background of every colored table on the page yellow. Yuck, huh?
+
+    % wget -q -O - http://slashdot.org/ | html2 | sed 's|table/@bgcolor=\(.*\)$|table/@bgcolor=yellow|' | 2html > slashdot.html
+    % netscape slashdot.html
+
+### Strip JavaScript from a Geocities home page.
+
+Geocities uses JavaScript to create an annoying little brand popup in the corner of their members' home pages. Let's delete it.
+
+    % wget -q -O - http://www.geocities.com/SiliconValley/Peaks/5957/xml.html |  html2 | grep -vi '^[^=]*/script[/=]' | 2html > xml.html
+    % netscape xml.html
+
+---
+
+Author: *Dan Egnor* (ofb.net/~egnor)<br/>
+Converted manually by *Lorenzo L. Ancora*, from HTML to MarkDown. All legal rights remain with the original author and this documentation is distributed non-profit.

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,0 +1,41 @@
+# XML/Unix Processing Tools
+
+## Introduction
+
+These tools are used to convert XML and HTML to and from a line-oriented format more amenable to processing by classic Unix pipeline processing tools, like `grep`, `sed`, `awk`, `cut`, shell scripts, and so forth.
+
+Documentation (reference.md) is available, and examples (examples.md) are illustrative.
+
+### Installation
+
+1. Fetch and install the `gnome-xml` library (`libxml`).<br/><br/>
+I'm using version 1.8.6. Other versions might or might not work.
+Make sure `xml-config` is on your path.
+
+2. Fetch and unpack the source tarball for my tools from this repository.<br/><br/>
+Look for a file named `xml2-version.tar.gz`.
+
+3. Run `make`.<br/><br/>You should now have several binaries: `xml2`, `2xml`, `csv2`, `2csv`.<br/>
+Symbolic links are used to offer alternative names: `html2` and `2html`.
+
+3. Copy the binaries and links somewhere.
+
+### Limitations
+
+- Namespace support is absent.
+
+- Whitespace isn't always preserved, and the rules for preserving and generating whitespace are complex.
+
+- It's possible to preserve all whitespace, but the resulting flat files are big and ugly. In most cases, whitespace is meaningless, used only to make the XML human-readable. Even in HTML, whitespace is sometimes significant and sometimes not, with no easy way to tell which is which.
+
+- XML is fundamentally hierarchical, not record-oriented.
+
+- The usefulness of record-oriented Unix tools to this domain will always be limited to simple operations like basic search and replacement, no matter how many syntactic transformations we make. More complex processing requires XML-specific tools like XSLT.
+
+- The transformation is complex.<br/><br/>
+The syntax used by these tools is relatively intuitive, but difficult to describe precisely. (My own documentation relies only on examples.) This makes it difficult to formally reason about data, so subtle errors are easy to make.
+
+---
+
+Author: *Dan Egnor* (ofb.net/~egnor)<br/>
+Converted manually by *Lorenzo L. Ancora*, from HTML to MarkDown. All legal rights remain with the original author and this documentation is distributed non-profit.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1,0 +1,175 @@
+# XML/Unix Processing Tools Documentation
+
+## Usage
+
+There are six tools. They are all simple filters, reading information from standard input in one format and writing the same information to standard output in a different format.
+
+| Tool name | Input        | Output |
+|-----------|--------------|--------|
+| xml2 	    | XML          | Flat   |
+| html2     | HTML 	       | Flat   |
+| csv2 	    | CSV          | Flat   |
+| 2xml 	    | Flat 	       | XML    |
+| 2html     | Flat 	       | HTML   |
+| 2csv 	    | Flat 	       | CSV    |
+
+The "Flat" format is specific to these tools. It is a syntax for representing structured markup in a way that makes it easy to process with line-oriented tools. The same format is used for HTML, XML, and CSV; in fact, you can think of `html2` as converting HTML to XHTML and running `xml2` on the result; likewise `2html` and `2xml`.
+
+CSV (comma-separated value) files are less expressive than XML or HTML (CSV has no hierarchy), so `xml2` | `2csv` is a lossy conversion.
+
+## File Format
+
+To use these tools effectively, it's important to understand the "Flat" format. Unfortunately, I'm lazy and sloppy; rather than provide a precise definition of the relationship between XML and "Flat", I will simply give you a pile of examples and hope you can generalize correctly.
+
+(Good luck!)
+
+<table>
+<tr><th>XML</th><th>Flat equivalent</th>
+
+<tr>
+<td>&lt;thing/&gt;</td>
+<td>/thing</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>&lt;thing&gt;&lt;subthing/&gt;&lt;/thing&gt;</td>
+<td>/thing/subthing</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>&lt;thing&gt;stuff&lt;/thing&gt;</td>
+<td>/thing=stuff</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>
+  &lt;thing&gt;<br>
+<span class="items">
+  &lt;subthing&gt;substuff&lt;/subthing&gt;<br>
+  stuff<br>
+</span>
+  &lt;/thing&gt;<br>
+</td>
+<td>
+  /thing/subthing=substuff<br>
+  /thing=stuff<br>
+</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>
+  &lt;person&gt;<br>
+<span class="items">
+  &lt;name&gt;Juan Do&eacute;&lt;/name&gt;<br>
+  &lt;occupation&gt;Zillionaire&lt;/occupation&gt;<br>
+  &lt;pet&gt;Dogcow&lt;/pet&gt;<br>
+  &lt;address&gt;<br>
+<span class="items">
+    123 Camino Real<br>
+    &lt;city&gt;El Dorado&lt;/city&gt;<br>
+    &lt;state&gt;AZ&lt;/state&gt;<br>
+    &lt;zip&gt;12345&lt;/zip&gt;<br>
+</span>
+  &lt;/address&gt;<br>
+  &lt;important/&gt;<br>
+</span>
+  &lt;/person&gt;<br>
+</td>
+<td>
+  /person/name=Juan Do&eacute;<br>
+  /person/occupation=Zillionaire<br>
+  /person/pet=Dogcow<br>
+  /person/address=123 Camino Real<br>
+  /person/address/city=El Dorado<br>
+  /person/address/state=AZ<br>
+  /person/address/zip=12345<br>
+  /person/important
+</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>
+  &lt;collection&gt;<br>
+<span class="items">
+    &lt;group&gt;<br>
+<span class="items">
+      &lt;thing&gt;stuff&lt;/thing&gt;<br>
+      &lt;thing&gt;stuff&lt;/thing&gt;<br>
+</span>
+    &lt;/group&gt;<br>
+</span>
+  &lt;/collection&gt;<br>
+</td>
+<td>
+  /collection/group/thing=stuff<br>
+  /collection/group/thing<br>
+  /collection/group/thing=stuff<br>
+</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>
+  &lt;collection&gt;<br>
+<span class="items">
+    &lt;group&gt;<br>
+<span class="items">
+      &lt;thing&gt;stuff&lt;/thing&gt;<br>
+</span>
+    &lt;/group&gt;<br>
+    &lt;group&gt;<br>
+<span class="items">
+      &lt;thing&gt;stuff&lt;/thing&gt;<br>
+</span>
+    &lt;/group&gt;<br>
+</span>
+  &lt;/collection&gt;<br>
+</td>
+<td>
+  /collection/group/thing=stuff<br>
+  /collection/group<br>
+  /collection/group/thing=stuff<br>
+</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>
+  &lt;thing&gt;<br>
+<span class="items">
+    stuff<br>
+    <br>
+    more stuff<br>
+    &amp;lt;other stuff&amp;gt;
+</span>
+  &lt;/thing&gt;<br>
+</td>
+<td>
+  /thing=stuff<br>
+  /thing=<br>
+  /thing=more stuff<br>
+  /thing=&lt;other stuff&gt;<br>
+</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>&lt;thing flag="value"&gt;stuff&lt;/thing&gt;</td>
+<td>
+  /thing/@flag=value<br>
+  /thing=stuff<br>
+</td>
+
+<tr><td colspan="2"><hr></td>
+<tr>
+<td>
+  &lt;?processing instruction?&gt;<br>
+  &lt;thing/&gt;
+<td>
+  /?processing=instruction<br>
+  /thing<br>
+</td>
+
+</table>
+
+---
+
+Author: *Dan Egnor* (ofb.net/~egnor)<br/>
+Converted manually by *Lorenzo L. Ancora*, from HTML to MarkDown. All legal rights remain with the original author and this documentation is distributed non-profit.


### PR DESCRIPTION
Fix issue #1 by creating the missing documentation, because the Wayback Machine is not an ideal source of documentation...
This should be enough to keep these utilities alive for a long time.